### PR TITLE
When cider is not a dependency, ns-resolve throws

### DIFF
--- a/src/ring/middleware/cider/debug.clj
+++ b/src/ring/middleware/cider/debug.clj
@@ -12,7 +12,8 @@
   leaves the global state alone (as it should), and therefore break points work
   correctly."
   [handler]
-  (let [*skip-breaks* (delay (ns-resolve 'cider.nrepl.middleware.debug '*skip-breaks*))]
+  (let [*skip-breaks* (delay (try (ns-resolve 'cider.nrepl.middleware.debug '*skip-breaks*)
+                                  (catch Exception _)))]
     (fn
       ([request]
        (if @*skip-breaks*


### PR DESCRIPTION
Instead, just treat as unresolved

Otherwise when using this wrapper without cider, the ns-resolve causes an error which prevents the server from serving requests.